### PR TITLE
Add medical GPT design document

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 # Code
-Laboratorio experimental para probar funciones de GitHub Copilot Codex con proyectos de automatización médica y educativa.
+
+Laboratorio experimental para probar funciones de GitHub Copilot Codex con proyectos de automatización médica y educativa. Este repositorio explora la creación de un GPT especializado en tareas médicas.
+
+Para más detalles consulte el documento [docs/medical-gpt-spec.md](docs/medical-gpt-spec.md).

--- a/docs/medical-gpt-spec.md
+++ b/docs/medical-gpt-spec.md
@@ -1,0 +1,27 @@
+# Medical GPT Specification
+
+This document was created following the instructions from the conversation:
+
+```
+1. Create a new file `docs/medical-gpt-spec.md` describing the GPT’s purpose, core functions, and examples (using the text from the conversation).
+2. Update `README.md` with a short description of the repository’s goal and a link to `docs/medical-gpt-spec.md`.
+3. Commit the new documentation with an informative commit message, e.g., “Add initial medical GPT design document.”
+```
+
+## Purpose
+
+The aim of this project is to experiment with GitHub Copilot Codex to build a medical GPT. The model will assist with automation and education in healthcare contexts.
+
+## Core Functions
+
+- Answer medical questions with concise and accurate information.
+- Automate common tasks in medical data management.
+- Provide educational explanations about medical topics.
+
+## Example Interaction
+
+```
+User: What is the dosage of medication X for adults?
+GPT: Provide the standard recommended dosage along with any warnings.
+```
+


### PR DESCRIPTION
## Summary
- document the purpose and functions of the planned medical GPT
- link to the design spec from the README

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_683fbc643934832ba9ac17652d42cfef