### PR TITLE
Fix syntax error in MedicalAgent

### DIFF
--- a/medical_agent.py
+++ b/medical_agent.py
@@ -34,7 +34,7 @@ class MedicalAgent:
     def suggest_treatment(self, diagnosis: str) -> str:
         """Suggest a treatment plan for the provided diagnosis."""
         prompt = (
-            f"Based on the diagnosis '{diagnosis}', suggest an appropriate treatment plan.""
+            f"Based on the diagnosis '{diagnosis}', suggest an appropriate treatment plan."
         )
         return self._chat(prompt)
 


### PR DESCRIPTION
## Summary
- fix string literal in suggest_treatment method

## Testing
- `python3 -m py_compile medical_agent.py`

------
https://chatgpt.com/codex/tasks/task_e_684280d86550832b9d5241490d80889a