### PR TITLE
Add image upload support to demo web app

### DIFF
--- a/web/app.py
+++ b/web/app.py
@@ -1,20 +1,50 @@
-"""Simple Flask interface for the MedicalImagingAgent."""
+"""Simple Flask interface for the MedicalImagingAgent with upload support."""
 
-from flask import Flask, render_template, request
+from flask import (
+    Flask,
+    render_template,
+    request,
+    send_from_directory,
+    url_for,
+)
+from werkzeug.utils import secure_filename
+import os
 from imaging_agent import MedicalImagingAgent
 
+UPLOAD_FOLDER = os.path.join(os.path.dirname(__file__), "uploads")
+os.makedirs(UPLOAD_FOLDER, exist_ok=True)
+
 app = Flask(__name__)
+app.config["UPLOAD_FOLDER"] = UPLOAD_FOLDER
 agent = MedicalImagingAgent()
+
+
+@app.route("/uploads/<filename>")
+def uploaded_file(filename: str):
+    """Serve uploaded files."""
+    return send_from_directory(app.config["UPLOAD_FOLDER"], filename)
 
 @app.route('/', methods=['GET', 'POST'])
 def index():
     response = None
+    image_url = None
     if request.method == 'POST':
         findings = request.form.get('findings', '')
-        image_path = request.form.get('image_path', '')
         age = request.form.get('age', '')
         sex = request.form.get('sex', '')
         task = request.form.get('task', 'report')
+
+        # Handle uploaded file
+        image_file = request.files.get('image_file')
+        image_path = request.form.get('image_path', '')
+        if image_file and image_file.filename:
+            filename = secure_filename(image_file.filename)
+            file_path = os.path.join(app.config['UPLOAD_FOLDER'], filename)
+            image_file.save(file_path)
+            image_path = file_path
+            if filename.lower().endswith(('.png', '.jpg', '.jpeg', '.gif')):
+                image_url = url_for('uploaded_file', filename=filename)
+
         patient_data = {"Edad": age, "Sexo": sex}
         if task == 'classification':
             response = agent.classify_image(image_path, patient_data)
@@ -26,7 +56,7 @@ def index():
             response = agent.multi_task_analysis(image_path, findings, patient_data)
         else:
             response = agent.generate_report(findings, patient_data)
-    return render_template('index.html', response=response)
+    return render_template('index.html', response=response, image_url=image_url)
 
 if __name__ == '__main__':
     app.run(debug=True)

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -6,11 +6,11 @@
   </head>
   <body>
     <h1>Medical Imaging Agent</h1>
-    <form method="post">
+    <form method="post" enctype="multipart/form-data">
       <label for="findings">Radiology Findings:</label><br>
       <textarea id="findings" name="findings" rows="4" cols="50"></textarea><br>
-      <label for="image_path">Image Path:</label>
-      <input type="text" id="image_path" name="image_path"><br>
+      <label for="image_file">Upload Image:</label>
+      <input type="file" id="image_file" name="image_file"><br>
       <label for="age">Age:</label>
       <input type="text" id="age" name="age" required><br>
       <label for="sex">Sex:</label>
@@ -25,9 +25,13 @@
       </select><br>
       <button type="submit">Run</button>
     </form>
-    {% if response %}
-    <h2>Response:</h2>
-    <p>{{ response }}</p>
-    {% endif %}
-  </body>
-</html>
+      {% if image_url %}
+      <h2>Uploaded Image:</h2>
+      <img src="{{ image_url }}" alt="uploaded image" style="max-width:500px;"><br>
+      {% endif %}
+      {% if response %}
+      <h2>Response:</h2>
+      <pre>{{ response }}</pre>
+      {% endif %}
+    </body>
+  </html>


### PR DESCRIPTION
## Summary
- accept uploaded imaging files in the Flask demo
- show the uploaded image and a summarized response

## Testing
- `pytest -q`
- `python -m py_compile web/app.py imaging_agent.py medical_agent.py`


------
https://chatgpt.com/codex/tasks/task_e_6843b45de240832bacf4164ff9eefddf