### PR TITLE
Add env var support for API key

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,26 @@ python web/app.py
 ```
 Luego visite `http://localhost:5000` e introduzca los datos solicitados para obtener
 resultados de ejemplo en la tarea seleccionada.
+
+## Configuración del API key
+
+`MedicalAgent` puede conectarse opcionalmente con la API de OpenAI. Si no se
+proporciona la clave al crear la instancia, la clase buscará las variables de
+entorno `MEDICAL_AGENT_API_KEY` o `OPENAI_API_KEY`.
+
+### Entorno local
+
+Defina la variable antes de ejecutar la aplicación o colóquela en un archivo
+`.env` que su gestor de entorno cargue automáticamente:
+
+```bash
+export OPENAI_API_KEY=sk-...
+python web/app.py
+```
+
+### Entorno de producción
+
+Durante el despliegue configure la variable `MEDICAL_AGENT_API_KEY` (o
+`OPENAI_API_KEY`) en el sistema o proporcione un archivo de configuración solo
+accesible para el servicio. De esta manera se evita exponer la clave en el
+código fuente.

--- a/medical_agent.py
+++ b/medical_agent.py
@@ -2,9 +2,22 @@ class MedicalAgent:
     """Simple medical agent implementing basic helper methods."""
 
     def __init__(self, api_key: str | None = None, model: str = "gpt-3.5-turbo"):
+        """Initialize the agent and configure optional OpenAI access.
+
+        The method checks the ``MEDICAL_AGENT_API_KEY`` or ``OPENAI_API_KEY``
+        environment variables when ``api_key`` is not explicitly provided. This
+        allows configuring the key without hardcoding it in the application.
+        """
+
+        import os
+
+        if api_key is None:
+            api_key = os.getenv("MEDICAL_AGENT_API_KEY") or os.getenv("OPENAI_API_KEY")
+
         self.api_key = api_key
         self.model = model
         self.openai = None
+
         if api_key:
             try:
                 import openai  # type: ignore


### PR DESCRIPTION
## Summary
- configure `MedicalAgent` to read API key from `MEDICAL_AGENT_API_KEY` or `OPENAI_API_KEY`
- document how to provide the key in local and production setups

## Testing
- `python -m py_compile medical_agent.py imaging_agent.py web/app.py`

------
https://chatgpt.com/codex/tasks/task_e_6843b7d53e44832bbadd9f67c7d3032d